### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ UIOffset anOffset = UIOffsetMake(20, 0);
 ```
 
 
-##License
+## License
 This project is under MIT License. See LICENSE file for more information.
 
 Except photos for the demo project which are part of *#portraitwithtongue* by [Adrimontaldovera](http://instagram.com/adrimontaldovera) Those are not under MIT License.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
